### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ exports[`test App renders correctly 1`] = `
 `;
 ```
 
-For more information, please take a look at https://github.com/keyanzhang/jest-css-modules-example/ and https://facebook.github.io/jest/docs/tutorial-webpack.html.
+For more information, please take a look at https://github.com/keyanzhang/jest-css-modules-example/ and https://jestjs.io/docs/en/webpack.html.
 
 ## Requirement
 No flag is required for Node.js `v6.*`; use `node --harmony_proxies` flag for `v5.*` and `v4.*`.


### PR DESCRIPTION
The link to the Jest Webpack-specific documentation in `README.md` goes to a 404 page. I have found what I would consider to be the equivalent updated page [here](https://jestjs.io/docs/en/webpack.html) and have changed the link in the readme accordingly.

Thank you for your time.