### PR TITLE
Be more defensive about accessing process.versions.node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ var Reflect; // eslint-disable-line no-unused-vars
 var idObj;
 
 function checkIsNodeV6OrAbove() {
-  if (typeof process === 'undefined') {
+  if (typeof process === 'undefined' || typeof process.versions === 'undefined' || typeof process.versions.node !== 'string') {
     return false;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ var Reflect; // eslint-disable-line no-unused-vars
 var idObj;
 
 function checkIsNodeV6OrAbove() {
-  if (typeof process === 'undefined' 
+  if (typeof process === 'undefined'
       || typeof process.versions === 'undefined'
       || typeof process.versions.node !== 'string') {
     return false;

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,9 @@ var Reflect; // eslint-disable-line no-unused-vars
 var idObj;
 
 function checkIsNodeV6OrAbove() {
-  if (typeof process === 'undefined' || typeof process.versions === 'undefined' || typeof process.versions.node !== 'string') {
+  if (typeof process === 'undefined' 
+      || typeof process.versions === 'undefined'
+      || typeof process.versions.node !== 'string') {
     return false;
   }
 


### PR DESCRIPTION
When using a browser process stub, it might not have `process.versions.node` set even if `process` is set.  This makes the `identity-obj-proxy` work in those environments.

Fixes https://github.com/keyz/identity-obj-proxy/issues/16
